### PR TITLE
fix : _expSystem public으로 수정

### DIFF
--- a/DevRkt_4th_Team3Test/Assets/Scripts/ui/LevelUI.cs
+++ b/DevRkt_4th_Team3Test/Assets/Scripts/ui/LevelUI.cs
@@ -11,7 +11,8 @@ public class LevelUI : MonoBehaviour
     public float _lerpSpeed = 5f;
     
     [Header("Data")]
-    [SerializeField]private ExpSystem _expSystem;
+    [SerializeField] public ExpSystem _expSystem;
+    
     
     void Update()
     {


### PR DESCRIPTION
 'LevelUI._expSystem' is inaccessible due to its protection level < 에러 수정했습니다.
 _expSystem를 public으로 변경했습니다. 혹시 게임매니저쪽 작업하실 수도 있을 것 같아 변수명은 그대로 두었습니다.